### PR TITLE
Psr6CacheClearer を使用してみる

### DIFF
--- a/src/Eccube/Util/CacheUtil.php
+++ b/src/Eccube/Util/CacheUtil.php
@@ -32,7 +32,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 class CacheUtil implements EventSubscriberInterface
 {
 
-    const DOCTRINE_APP_CACHE_KEY = 'cache.doctrine.orm.default.metadata';
+    const DOCTRINE_APP_CACHE_KEY = 'doctrine.app_cache_pool';
 
     private $clearCacheAfterResponse = false;
 

--- a/src/Eccube/Util/CacheUtil.php
+++ b/src/Eccube/Util/CacheUtil.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer;
 use Symfony\Component\HttpKernel\Event\PostResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -30,6 +31,9 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 class CacheUtil implements EventSubscriberInterface
 {
+
+    const DOCTRINE_APP_CACHE_KEY = 'cache.doctrine.orm.default.metadata';
+
     private $clearCacheAfterResponse = false;
 
     /**
@@ -114,12 +118,18 @@ class CacheUtil implements EventSubscriberInterface
      */
     public function clearDoctrineCache()
     {
+        /** @var Psr6CacheClearer $poolClearer */
+        $poolClearer = $this->container->get('cache.global_clearer');
+        if (!$poolClearer->hasPool(self::DOCTRINE_APP_CACHE_KEY)) {
+            return;
+        }
+
         $console = new Application($this->kernel);
         $console->setAutoExit(false);
 
         $command = [
             'command' => 'cache:pool:clear',
-            'pools' => ['cache.app_clearer'],
+            'pools' => [self::DOCTRINE_APP_CACHE_KEY],
             '--no-ansi' => true,
         ];
 


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

Doctrine のキャッシュをクリアする

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

極力、Symfony3.4 の動作を踏襲するようDoctrine のキャッシュのみをクリアしたい

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

`Symfony\Bundle\FrameworkBundle\Command\CachePoolClearCommand` を見てみると、  `Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer` でキャッシュの存在チェックができそうで、 public のコンポーネントになっていたため、こちらのインスタンスを使用しました。

キャッシュのIDは以下で確認

```shell
bin/console cache:pool:list
 ------------------------------------- 
  Pool name                            
 ------------------------------------- 
  cache.app                            
  cache.system                         
  cache.validator                      
  cache.serializer                     
  cache.annotations                    
  cache.property_info                  
  cache.security_expression_language   
  cache.doctrine.orm.default.metadata  
  cache.doctrine.orm.default.query     
 ------------------------------------- 
```

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->

## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->

`cache.doctrine.orm.default.query` も削除が必要かも

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
