### PR TITLE
プラグイン有効化URLのチェックを追加

### DIFF
--- a/src/Eccube/Controller/InstallPluginController.php
+++ b/src/Eccube/Controller/InstallPluginController.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Controller;
+
+use Eccube\Controller\Install\InstallController;
+use Eccube\Entity\Plugin;
+use Eccube\Service\PluginService;
+use Eccube\Service\SystemService;
+use Eccube\Util\CacheUtil;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Annotation\Route;
+
+class InstallPluginController extends InstallController
+{
+    /**
+     * プラグインを有効にします。
+     *
+     * @Route("/install/plugin/enable", name="install_plugin_enable")
+     *
+     * @return JsonResponse
+     *
+     * @throws PluginException
+     */
+    public function pluginEnable(CacheUtil $cacheUtil, SystemService $systemService, PluginService $pluginService)
+    {
+        // トランザクションチェックファイルの有効期限を確認する
+        $projectDir = $this->getParameter('kernel.project_dir');
+        if (!file_exists($projectDir.parent::TRANSACTION_CHECK_FILE)) {
+            throw new NotFoundHttpException();
+        }
+
+        $transaction_checker = file_get_contents($projectDir.parent::TRANSACTION_CHECK_FILE);
+        if ($transaction_checker < time()) {
+            throw new NotFoundHttpException();
+        }
+
+        $Plugin = $this->entityManager->getRepository(Plugin::class)->findOneBy(['code' => 'Api']);
+        $log = null;
+        // プラグインが存在しない場合は無視する
+        if ($Plugin !== null) {
+
+            $systemService->switchMaintenance(true); // auto_maintenanceと設定されたファイルを生成
+            $systemService->disableMaintenance(SystemService::AUTO_MAINTENANCE);
+            $cacheUtil->clearCache();
+
+            try {
+                ob_start();
+
+                $pluginService->installWithCode($Plugin->getCode());
+
+                $pluginService->enable($Plugin);
+            } finally {
+                $log = ob_get_clean();
+                while (ob_get_level() > 0) {
+                    ob_end_flush();
+                }
+            }
+        }
+
+        unlink($projectDir.parent::TRANSACTION_CHECK_FILE);
+
+        return $this->json(['success' => true, 'log' => $log]);
+    }
+}


### PR DESCRIPTION
- APP_ENV=prod では InstallController を参照できないため、 `Eccube\Controller\InstallPluginController` を作成
- 有効期限を書き込んだファイルを生成する
- 有効化URLでファイルの存在と有効期限をチェックをする
- .ht から始まるファイル名にしておけば、 Apache の場合は外部から参照できない
- とり急ぎプラグインコードをベタ書きで対応
